### PR TITLE
refactor : OAuth2 + JWT 보안 강화

### DIFF
--- a/src/main/java/com/popflix/auth/dto/TokenDto.java
+++ b/src/main/java/com/popflix/auth/dto/TokenDto.java
@@ -17,7 +17,7 @@ public class TokenDto {
     @NoArgsConstructor
     @AllArgsConstructor
     public static class Request {
-        private String refreshToken;
+        private String accessToken;
     }
 
     @Getter
@@ -26,6 +26,5 @@ public class TokenDto {
     @AllArgsConstructor
     public static class Response {
         private String accessToken;
-        private String refreshToken;
     }
 }

--- a/src/main/java/com/popflix/auth/exception/AuthExceptionHandler.java
+++ b/src/main/java/com/popflix/auth/exception/AuthExceptionHandler.java
@@ -1,0 +1,77 @@
+package com.popflix.auth.exception;
+
+import com.popflix.auth.util.CookieUtil;
+import com.popflix.global.util.ApiUtil;
+import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
+import org.springframework.http.HttpStatus;
+import org.springframework.http.ResponseEntity;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.web.bind.annotation.ExceptionHandler;
+import org.springframework.web.bind.annotation.RestControllerAdvice;
+
+@RestControllerAdvice
+@RequiredArgsConstructor
+public class AuthExceptionHandler {
+
+    private final CookieUtil cookieUtil;
+
+    @ExceptionHandler(InvalidTokenException.class)
+    public ResponseEntity<?> handleInvalidTokenException(InvalidTokenException e, HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    public ResponseEntity<?> handleTokenExpiredException(TokenExpiredException e, HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(RefreshTokenException.class)
+    public ResponseEntity<?> handleRefreshTokenException(RefreshTokenException e, HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(InvalidCookieException.class)
+    public ResponseEntity<?> handleInvalidCookieException(InvalidCookieException e, HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+        return ResponseEntity
+                .status(HttpStatus.BAD_REQUEST)
+                .body(ApiUtil.error(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(BlacklistedTokenException.class)
+    public ResponseEntity<?> handleBlacklistedTokenException(BlacklistedTokenException e, HttpServletResponse response) {
+        cookieUtil.deleteAccessTokenCookie(response);
+        cookieUtil.deleteRefreshTokenCookie(response);
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    public ResponseEntity<?> handleAuthenticationException(AuthenticationException e) {
+        return ResponseEntity
+                .status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), "인증에 실패했습니다: " + e.getMessage()));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    public ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e) {
+        return ResponseEntity
+                .status(HttpStatus.FORBIDDEN)
+                .body(ApiUtil.error(HttpStatus.FORBIDDEN.value(), "접근이 거부되었습니다: " + e.getMessage()));
+    }
+}

--- a/src/main/java/com/popflix/auth/exception/BlacklistedTokenException.java
+++ b/src/main/java/com/popflix/auth/exception/BlacklistedTokenException.java
@@ -1,0 +1,7 @@
+package com.popflix.auth.exception;
+
+public class BlacklistedTokenException extends RuntimeException {
+    public BlacklistedTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/popflix/auth/exception/InvalidCookieException.java
+++ b/src/main/java/com/popflix/auth/exception/InvalidCookieException.java
@@ -1,0 +1,7 @@
+package com.popflix.auth.exception;
+
+public class InvalidCookieException extends RuntimeException {
+    public InvalidCookieException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/popflix/auth/exception/InvalidTokenException.java
+++ b/src/main/java/com/popflix/auth/exception/InvalidTokenException.java
@@ -1,0 +1,7 @@
+package com.popflix.auth.exception;
+
+public class InvalidTokenException extends RuntimeException {
+    public InvalidTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/popflix/auth/exception/RefreshTokenException.java
+++ b/src/main/java/com/popflix/auth/exception/RefreshTokenException.java
@@ -1,0 +1,7 @@
+package com.popflix.auth.exception;
+
+public class RefreshTokenException extends RuntimeException {
+    public RefreshTokenException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/popflix/auth/exception/TokenExpiredException.java
+++ b/src/main/java/com/popflix/auth/exception/TokenExpiredException.java
@@ -1,0 +1,7 @@
+package com.popflix.auth.exception;
+
+public class TokenExpiredException extends RuntimeException {
+    public TokenExpiredException(String message) {
+        super(message);
+    }
+}

--- a/src/main/java/com/popflix/auth/oauth2/handler/OAuth2AuthenticationFailureHandler.java
+++ b/src/main/java/com/popflix/auth/oauth2/handler/OAuth2AuthenticationFailureHandler.java
@@ -1,8 +1,11 @@
 package com.popflix.auth.oauth2.handler;
 
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.AuthenticationException;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationFailureHandler;
 import org.springframework.stereotype.Component;
@@ -12,16 +15,37 @@ import java.io.IOException;
 
 @Slf4j
 @Component
+@RequiredArgsConstructor
 public class OAuth2AuthenticationFailureHandler extends SimpleUrlAuthenticationFailureHandler {
+
+    @Value("${app.auth.cookie.domain}")
+    private String domain;
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 
     @Override
     public void onAuthenticationFailure(HttpServletRequest request, HttpServletResponse response,
                                         AuthenticationException exception) throws IOException {
+
+        log.error("OAuth2 authentication failed: {}", exception.getMessage());
+
+        deleteCookie(response, ACCESS_TOKEN_COOKIE_NAME);
+        deleteCookie(response, REFRESH_TOKEN_COOKIE_NAME);
 
         String targetUrl = UriComponentsBuilder.fromUriString("/auth/login")
                 .queryParam("error", exception.getLocalizedMessage())
                 .build().toUriString();
 
         getRedirectStrategy().sendRedirect(request, response, targetUrl);
+    }
+
+    private void deleteCookie(HttpServletResponse response, String name) {
+        Cookie cookie = new Cookie(name, "");
+        cookie.setDomain(domain);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setMaxAge(0);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/popflix/auth/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
+++ b/src/main/java/com/popflix/auth/oauth2/handler/OAuth2AuthenticationSuccessHandler.java
@@ -1,80 +1,87 @@
 package com.popflix.auth.oauth2.handler;
 
-import com.popflix.auth.token.TokenProvider;
 import com.popflix.domain.user.entity.User;
 import com.popflix.domain.user.exception.UserNotFoundException;
 import com.popflix.domain.user.repository.UserRepository;
+import jakarta.servlet.http.Cookie;
 import jakarta.servlet.http.HttpServletRequest;
 import jakarta.servlet.http.HttpServletResponse;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
-import org.springframework.data.redis.core.RedisTemplate;
+import org.springframework.beans.factory.annotation.Value;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.security.web.authentication.SimpleUrlAuthenticationSuccessHandler;
 import org.springframework.stereotype.Component;
 import org.springframework.web.util.UriComponentsBuilder;
+import com.popflix.auth.token.TokenProvider;
 
 import java.io.IOException;
 import java.util.Map;
-import java.util.concurrent.TimeUnit;
 
+@Slf4j
 @Component
 @RequiredArgsConstructor
-@Slf4j
 public class OAuth2AuthenticationSuccessHandler extends SimpleUrlAuthenticationSuccessHandler {
 
     private final TokenProvider tokenProvider;
-    private final RedisTemplate<String, String> redisTemplate;
     private final UserRepository userRepository;
+
+    @Value("${app.auth.cookie.domain}")
+    private String domain;
+
+    @Value("${app.auth.cookie.secure}")
+    private boolean secure;
+
+    private static final String ACCESS_TOKEN_COOKIE_NAME = "access_token";
+    private static final String REFRESH_TOKEN_COOKIE_NAME = "refresh_token";
 
     @Override
     public void onAuthenticationSuccess(HttpServletRequest request, HttpServletResponse response,
                                         Authentication authentication) throws IOException {
-        String targetUrl = determineTargetUrl(authentication);
-
-        if (response.isCommitted()) {
-            logger.debug("Response has already been committed");
-            return;
-        }
-
-        clearAuthenticationAttributes(request);
-        getRedirectStrategy().sendRedirect(request, response, targetUrl);
-    }
-
-    protected String determineTargetUrl(Authentication authentication) {
-        String accessToken = tokenProvider.createAccessToken(authentication);
-        String refreshToken = tokenProvider.createRefreshToken(authentication);
-
-        log.info("Access Token: Bearer {}", accessToken);
-        log.info("Refresh Token: Bearer {}", refreshToken);
 
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
         String registrationId = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
-
         String id;
+
         if ("naver".equals(registrationId)) {
-            Map<String, Object> response = (Map<String, Object>) oauth2User.getAttributes().get("response");
-            id = (String) response.get("id");
+            Map<String, Object> response_data = (Map<String, Object>) oauth2User.getAttributes().get("response");
+            id = (String) response_data.get("id");
         } else {
             id = oauth2User.getAttribute("sub");
         }
+
         String socialId = registrationId + "_" + id;
+        String accessToken = tokenProvider.createAccessToken(authentication);
+        log.info("Generated Access Token: Bearer {}", accessToken);
+        String refreshToken = tokenProvider.createRefreshToken(authentication);
+
+        addTokenCookie(response, ACCESS_TOKEN_COOKIE_NAME, accessToken,
+                (int) (tokenProvider.getAccessTokenValidityTime() / 1000));
+        addTokenCookie(response, REFRESH_TOKEN_COOKIE_NAME, refreshToken,
+                (int) (tokenProvider.getRefreshTokenValidityTime() / 1000));
 
         User user = userRepository.findBySocialId(socialId)
                 .orElseThrow(UserNotFoundException::new);
 
-        redisTemplate.opsForValue()
-                .set("RT:" + socialId, refreshToken, 30, TimeUnit.DAYS);
-
         String targetUrl = user.getNickname() == null ?
                 "/auth/register" : "/";
 
-        return UriComponentsBuilder.fromUriString(targetUrl)
-                .queryParam("accessToken", "Bearer " + accessToken)
-                .queryParam("refreshToken", "Bearer " + refreshToken)
+        String redirectUrl = UriComponentsBuilder.fromUriString(targetUrl)
                 .queryParam("isNewUser", user.getNickname() == null)
                 .build().toUriString();
+
+        getRedirectStrategy().sendRedirect(request, response, redirectUrl);
+    }
+
+    private void addTokenCookie(HttpServletResponse response, String name, String value, int maxAge) {
+        Cookie cookie = new Cookie(name, value);
+        cookie.setDomain(domain);
+        cookie.setPath("/");
+        cookie.setHttpOnly(true);
+        cookie.setSecure(secure);
+        cookie.setMaxAge(maxAge);
+        response.addCookie(cookie);
     }
 }

--- a/src/main/java/com/popflix/auth/service/AuthService.java
+++ b/src/main/java/com/popflix/auth/service/AuthService.java
@@ -1,5 +1,6 @@
 package com.popflix.auth.service;
 
+import com.popflix.auth.token.TokenProvider;
 import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.data.redis.core.RedisTemplate;
@@ -13,6 +14,7 @@ import java.util.concurrent.TimeUnit;
 public class AuthService {
 
     private final RedisTemplate<String, String> redisTemplate;
+    private final TokenProvider tokenProvider;
 
     public void logout(String accessToken, String socialId) {
         String token = accessToken.startsWith("Bearer ")
@@ -37,6 +39,6 @@ public class AuthService {
         redisTemplate.delete("RT:" + socialId);
         redisTemplate.opsForValue()
                 .set("RT:" + socialId, newRefreshToken,
-                        30, TimeUnit.DAYS);
+                        tokenProvider.getRefreshTokenValidityTime(), TimeUnit.MILLISECONDS);
     }
 }

--- a/src/main/java/com/popflix/auth/token/TokenProvider.java
+++ b/src/main/java/com/popflix/auth/token/TokenProvider.java
@@ -2,8 +2,11 @@ package com.popflix.auth.token;
 
 import io.jsonwebtoken.*;
 import io.jsonwebtoken.security.Keys;
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.beans.factory.annotation.Value;
+import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.security.authentication.UsernamePasswordAuthenticationToken;
 import org.springframework.security.core.Authentication;
 import org.springframework.security.core.GrantedAuthority;
@@ -12,94 +15,169 @@ import org.springframework.security.core.userdetails.User;
 import org.springframework.security.oauth2.client.authentication.OAuth2AuthenticationToken;
 import org.springframework.security.oauth2.core.user.OAuth2User;
 import org.springframework.stereotype.Component;
+import org.springframework.util.StringUtils;
 
-import java.security.Key;
-import java.util.Arrays;
-import java.util.Collection;
-import java.util.Date;
-import java.util.Map;
+import javax.crypto.SecretKey;
+import java.nio.charset.StandardCharsets;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.*;
+import java.util.concurrent.TimeUnit;
 import java.util.stream.Collectors;
 
 @Slf4j
 @Component
 public class TokenProvider {
 
-    private final Key key;
+    private final SecretKey key;
     private final long accessTokenValidityTime;
     private final long refreshTokenValidityTime;
+    private final RedisTemplate<String, String> redisTemplate;
+    private static final String COOKIE_ACCESS_TOKEN_KEY = "access_token";
+    private static final String REDIS_REFRESH_TOKEN_PREFIX = "RT:";
+    private static final String REDIS_BLACKLIST_PREFIX = "BL:";
 
     public TokenProvider(
             @Value("${jwt.secret}") String secret,
             @Value("${jwt.access-token-validity}") long accessTokenValidityTime,
-            @Value("${jwt.refresh-token-validity}") long refreshTokenValidityTime) {
-        byte[] keyBytes = secret.getBytes();
+            @Value("${jwt.refresh-token-validity}") long refreshTokenValidityTime,
+            RedisTemplate<String, String> redisTemplate) {
+        byte[] keyBytes = secret.getBytes(StandardCharsets.UTF_8);
+        try {
+            MessageDigest digest = MessageDigest.getInstance("SHA-512");
+            keyBytes = digest.digest(keyBytes);
+        } catch (NoSuchAlgorithmException e) {
+            throw new RuntimeException("Failed to generate secure key", e);
+        }
+
         this.key = Keys.hmacShaKeyFor(keyBytes);
         this.accessTokenValidityTime = accessTokenValidityTime;
         this.refreshTokenValidityTime = refreshTokenValidityTime;
+        this.redisTemplate = redisTemplate;
     }
 
     public String createAccessToken(Authentication authentication) {
         OAuth2User oauth2User = (OAuth2User) authentication.getPrincipal();
         String registrationId = ((OAuth2AuthenticationToken) authentication).getAuthorizedClientRegistrationId();
-        String id;
-
-        if ("naver".equals(registrationId)) {
-            Map<String, Object> response = (Map<String, Object>) oauth2User.getAttributes().get("response");
-            id = (String) response.get("id");
-        } else {
-            id = oauth2User.getAttribute("sub");
-        }
+        String id = extractSocialId(oauth2User, registrationId);
         String socialId = registrationId + "_" + id;
 
         String authorities = authentication.getAuthorities().stream()
                 .map(GrantedAuthority::getAuthority)
                 .collect(Collectors.joining(","));
 
-        long now = (new Date()).getTime();
-        Date validity = new Date(now + this.accessTokenValidityTime);
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + accessTokenValidityTime);
+
+        Map<String, Object> claims = new HashMap<>();
+        claims.put("auth", authorities);
+        claims.put("type", "access");
 
         return Jwts.builder()
                 .setSubject(socialId)
-                .claim("auth", authorities)
-                .signWith(key, SignatureAlgorithm.HS512)
+                .addClaims(claims)
+                .setIssuedAt(now)
                 .setExpiration(validity)
+                .signWith(key)
                 .compact();
     }
 
     public String createRefreshToken(Authentication authentication) {
-        long now = (new Date()).getTime();
-        Date validity = new Date(now + this.refreshTokenValidityTime);
+        String socialId = authentication.getName();
+        Date now = new Date();
+        Date validity = new Date(now.getTime() + refreshTokenValidityTime);
 
-        return Jwts.builder()
-                .setSubject(authentication.getName())
-                .signWith(key, SignatureAlgorithm.HS512)
+        String refreshToken = Jwts.builder()
+                .setSubject(socialId)
+                .claim("type", "refresh")
+                .setIssuedAt(now)
                 .setExpiration(validity)
+                .signWith(key)
                 .compact();
+
+        redisTemplate.opsForValue().set(
+                REDIS_REFRESH_TOKEN_PREFIX + socialId,
+                refreshToken,
+                refreshTokenValidityTime,
+                TimeUnit.MILLISECONDS
+        );
+
+        return refreshToken;
+    }
+
+    public void addToBlacklist(String token) {
+        Claims claims = parseToken(token);
+        long remainingTime = claims.getExpiration().getTime() - System.currentTimeMillis();
+        if (remainingTime > 0) {
+            redisTemplate.opsForValue().set(
+                    REDIS_BLACKLIST_PREFIX + token,
+                    "blacklisted",
+                    remainingTime,
+                    TimeUnit.MILLISECONDS
+            );
+        }
+    }
+
+    public String resolveToken(HttpServletRequest request) {
+        String bearerToken = request.getHeader("Authorization");
+        if (StringUtils.hasText(bearerToken) && bearerToken.startsWith("Bearer ")) {
+            return bearerToken.substring(7);
+        }
+
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (COOKIE_ACCESS_TOKEN_KEY.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
     }
 
     public Authentication getAuthentication(String token) {
         Claims claims = parseToken(token);
-        log.info("Token claims: {}", claims);
 
         Collection<? extends GrantedAuthority> authorities =
-                Arrays.stream(claims.get("auth").toString().split(","))
+                Arrays.stream(claims.get("auth", String.class).split(","))
                         .map(SimpleGrantedAuthority::new)
                         .collect(Collectors.toList());
 
         User principal = new User(claims.getSubject(), "", authorities);
-        log.info("Created principal: {}", principal);
-
         return new UsernamePasswordAuthenticationToken(principal, token, authorities);
     }
 
     public boolean validateToken(String token) {
         try {
-            Jwts.parserBuilder().setSigningKey(key).build().parseClaimsJws(token);
-            return true;
+            if (isTokenBlacklisted(token)) {
+                return false;
+            }
+
+            Claims claims = parseToken(token);
+            return !claims.getExpiration().before(new Date());
         } catch (JwtException | IllegalArgumentException e) {
-            log.info("Invalid JWT token: {}", e.getMessage());
+            log.error("Invalid JWT token: {}", e.getMessage());
             return false;
         }
+    }
+
+    public boolean validateRefreshToken(String refreshToken, String socialId) {
+        String storedToken = redisTemplate.opsForValue().get(REDIS_REFRESH_TOKEN_PREFIX + socialId);
+        if (!refreshToken.equals(storedToken)) {
+            return false;
+        }
+
+        try {
+            Claims claims = parseToken(refreshToken);
+            return "refresh".equals(claims.get("type")) && !claims.getExpiration().before(new Date());
+        } catch (JwtException | IllegalArgumentException e) {
+            log.error("Invalid refresh token: {}", e.getMessage());
+            return false;
+        }
+    }
+
+    private boolean isTokenBlacklisted(String token) {
+        return Boolean.TRUE.equals(redisTemplate.hasKey(REDIS_BLACKLIST_PREFIX + token));
     }
 
     private Claims parseToken(String token) {
@@ -108,5 +186,21 @@ public class TokenProvider {
                 .build()
                 .parseClaimsJws(token)
                 .getBody();
+    }
+
+    private String extractSocialId(OAuth2User oauth2User, String registrationId) {
+        if ("naver".equals(registrationId)) {
+            Map<String, Object> response = (Map<String, Object>) oauth2User.getAttributes().get("response");
+            return (String) response.get("id");
+        }
+        return oauth2User.getAttribute("sub");
+    }
+
+    public long getAccessTokenValidityTime() {
+        return accessTokenValidityTime;
+    }
+
+    public long getRefreshTokenValidityTime() {
+        return refreshTokenValidityTime;
     }
 }

--- a/src/main/java/com/popflix/auth/util/CookieUtil.java
+++ b/src/main/java/com/popflix/auth/util/CookieUtil.java
@@ -1,0 +1,106 @@
+package com.popflix.auth.util;
+
+import jakarta.servlet.http.Cookie;
+import jakarta.servlet.http.HttpServletRequest;
+import jakarta.servlet.http.HttpServletResponse;
+import org.springframework.beans.factory.annotation.Value;
+import org.springframework.http.ResponseCookie;
+import org.springframework.stereotype.Component;
+
+@Component
+public class CookieUtil {
+
+    @Value("${app.auth.cookie.domain}")
+    private String domain;
+
+    @Value("${app.auth.cookie.secure}")
+    private boolean secure;
+
+    @Value("${app.auth.cookie.access-token-name}")
+    private String accessTokenName;
+
+    @Value("${app.auth.cookie.refresh-token-name}")
+    private String refreshTokenName;
+
+    @Value("${app.auth.cookie.access-token-expiry}")
+    private int accessTokenExpiry;
+
+    @Value("${app.auth.cookie.refresh-token-expiry}")
+    private int refreshTokenExpiry;
+
+    public void addAccessTokenCookie(HttpServletResponse response, String token) {
+        ResponseCookie cookie = ResponseCookie.from(accessTokenName, token)
+                .domain(domain)
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .maxAge(accessTokenExpiry)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void addRefreshTokenCookie(HttpServletResponse response, String token) {
+        ResponseCookie cookie = ResponseCookie.from(refreshTokenName, token)
+                .domain(domain)
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .maxAge(refreshTokenExpiry)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void deleteAccessTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(accessTokenName, "")
+                .domain(domain)
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public void deleteRefreshTokenCookie(HttpServletResponse response) {
+        ResponseCookie cookie = ResponseCookie.from(refreshTokenName, "")
+                .domain(domain)
+                .path("/")
+                .httpOnly(true)
+                .secure(secure)
+                .sameSite("Lax")
+                .maxAge(0)
+                .build();
+
+        response.addHeader("Set-Cookie", cookie.toString());
+    }
+
+    public String getAccessTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (accessTokenName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+
+    public String getRefreshTokenFromCookie(HttpServletRequest request) {
+        Cookie[] cookies = request.getCookies();
+        if (cookies != null) {
+            for (Cookie cookie : cookies) {
+                if (refreshTokenName.equals(cookie.getName())) {
+                    return cookie.getValue();
+                }
+            }
+        }
+        return null;
+    }
+}

--- a/src/main/java/com/popflix/common/exception/handler/GlobalExceptionHandler.java
+++ b/src/main/java/com/popflix/common/exception/handler/GlobalExceptionHandler.java
@@ -1,5 +1,6 @@
 package com.popflix.common.exception.handler;
 
+import com.popflix.auth.exception.*;
 import com.popflix.domain.movie.exception.MovieNotFoundException;
 import com.popflix.domain.storage.exception.AccessStorageDeniedException;
 import com.popflix.domain.storage.exception.DuplicateMovieException;
@@ -9,92 +10,136 @@ import com.popflix.domain.user.exception.DuplicateEmailException;
 import com.popflix.domain.user.exception.DuplicateNicknameException;
 import com.popflix.domain.user.exception.UserNotFoundException;
 import com.popflix.global.util.ApiUtil;
-import com.popflix.global.util.ApiUtil.ApiError;
 import jakarta.servlet.http.HttpServletResponse;
+import lombok.RequiredArgsConstructor;
 import lombok.extern.slf4j.Slf4j;
 import org.springframework.http.HttpHeaders;
+import org.springframework.http.HttpStatus;
 import org.springframework.http.HttpStatusCode;
 import org.springframework.http.ResponseEntity;
+import org.springframework.security.access.AccessDeniedException;
+import org.springframework.security.core.AuthenticationException;
+import org.springframework.web.bind.MethodArgumentNotValidException;
 import org.springframework.web.bind.annotation.ExceptionHandler;
 import org.springframework.web.bind.annotation.RestControllerAdvice;
 import org.springframework.web.context.request.WebRequest;
 import org.springframework.web.servlet.mvc.method.annotation.ResponseEntityExceptionHandler;
 
-import java.nio.file.AccessDeniedException;
-
 
 @Slf4j
 @RestControllerAdvice
+@RequiredArgsConstructor
 public class GlobalExceptionHandler extends ResponseEntityExceptionHandler {
 
     @Override
-    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body, HttpHeaders headers,
-                                                             HttpStatusCode statusCode, WebRequest request) {
-        log.error(ex.getMessage(), ex);
-
-        ApiUtil.ApiError<String> error = ApiUtil.error(statusCode.value(), "알 수 없는 오류가 발생했습니다. 문의 바랍니다.");
+    protected ResponseEntity<Object> handleExceptionInternal(Exception ex, Object body,
+                                                             HttpHeaders headers, HttpStatusCode statusCode, WebRequest request) {
+        log.error("Handling {} - {}", ex.getClass().getSimpleName(), ex.getMessage(), ex);
+        ApiUtil.ApiError<String> error = ApiUtil.error(statusCode.value(), "서버 오류가 발생했습니다. 관리자에게 문의해주세요.");
         return super.handleExceptionInternal(ex, error, headers, statusCode, request);
+    }
+
+    @Override
+    protected ResponseEntity<Object> handleMethodArgumentNotValid(MethodArgumentNotValidException ex,
+                                                                  HttpHeaders headers, HttpStatusCode status, WebRequest request) {
+        String errorMessage = ex.getBindingResult().getFieldErrors().stream()
+                .map(error -> error.getField() + ": " + error.getDefaultMessage())
+                .reduce((a, b) -> a + "; " + b)
+                .orElse("유효성 검사 실패");
+
+        ApiUtil.ApiError<String> error = ApiUtil.error(status.value(), errorMessage);
+        return new ResponseEntity<>(error, headers, status);
+    }
+
+    @ExceptionHandler(InvalidTokenException.class)
+    protected ResponseEntity<?> handleInvalidTokenException(InvalidTokenException e) {
+        log.error("Invalid token: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(TokenExpiredException.class)
+    protected ResponseEntity<?> handleTokenExpiredException(TokenExpiredException e) {
+        log.error("Token expired: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), e.getMessage()));
+    }
+
+    @ExceptionHandler(AuthenticationException.class)
+    protected ResponseEntity<?> handleAuthenticationException(AuthenticationException e) {
+        log.error("Authentication failed: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.UNAUTHORIZED)
+                .body(ApiUtil.error(HttpStatus.UNAUTHORIZED.value(), "인증에 실패했습니다."));
+    }
+
+    @ExceptionHandler(AccessDeniedException.class)
+    protected ResponseEntity<?> handleAccessDeniedException(AccessDeniedException e) {
+        log.error("Access denied: {}", e.getMessage(), e);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiUtil.error(HttpStatus.FORBIDDEN.value(), "접근 권한이 없습니다."));
     }
 
     @ExceptionHandler(DuplicateStorageNameException.class)
     protected ResponseEntity<?> handleDuplicateStorageNameException(DuplicateStorageNameException e) {
         log.error(e.getMessage(), e);
-        ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-
-        return ResponseEntity.status(HttpServletResponse.SC_NOT_FOUND).body(error);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiUtil.error(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
     }
 
     @ExceptionHandler(DuplicateMovieException.class)
     protected ResponseEntity<?> handleDuplicateMovieException(DuplicateMovieException e) {
         log.error(e.getMessage(), e);
-        ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-
-        return ResponseEntity.status(HttpServletResponse.SC_BAD_REQUEST).body(error);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiUtil.error(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
     }
 
     @ExceptionHandler(AccessStorageDeniedException.class)
-    protected ResponseEntity<?> handleAccessDeniedException(AccessStorageDeniedException e) {
+    protected ResponseEntity<?> handleAccessStorageDeniedException(AccessStorageDeniedException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_FORBIDDEN, e.getMessage());
-
-        return ResponseEntity.status(HttpServletResponse.SC_FORBIDDEN).body(error);
+        return ResponseEntity.status(HttpStatus.FORBIDDEN)
+                .body(ApiUtil.error(HttpStatus.FORBIDDEN.value(), e.getMessage()));
     }
 
     @ExceptionHandler(StorageNotFoundException.class)
     protected ResponseEntity<?> handleStorageNotFoundException(StorageNotFoundException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-
-        return ResponseEntity.status(HttpServletResponse.SC_BAD_REQUEST).body(error);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiUtil.error(HttpStatus.NOT_FOUND.value(), e.getMessage()));
     }
 
     @ExceptionHandler(MovieNotFoundException.class)
     protected ResponseEntity<?> handleMovieNotFoundException(MovieNotFoundException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-
-        return ResponseEntity.status(HttpServletResponse.SC_BAD_REQUEST).body(error);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiUtil.error(HttpStatus.NOT_FOUND.value(), e.getMessage()));
     }
 
     @ExceptionHandler(UserNotFoundException.class)
     protected ResponseEntity<?> handleUserNotFoundException(UserNotFoundException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_NOT_FOUND, e.getMessage());
-        return ResponseEntity.status(HttpServletResponse.SC_NOT_FOUND).body(error);
+        return ResponseEntity.status(HttpStatus.NOT_FOUND)
+                .body(ApiUtil.error(HttpStatus.NOT_FOUND.value(), e.getMessage()));
     }
 
     @ExceptionHandler(DuplicateEmailException.class)
     protected ResponseEntity<?> handleDuplicateEmailException(DuplicateEmailException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-        return ResponseEntity.status(HttpServletResponse.SC_BAD_REQUEST).body(error);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiUtil.error(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
     }
 
     @ExceptionHandler(DuplicateNicknameException.class)
     protected ResponseEntity<?> handleDuplicateNicknameException(DuplicateNicknameException e) {
         log.error(e.getMessage(), e);
-        ApiUtil.ApiError<String> error = ApiUtil.error(HttpServletResponse.SC_BAD_REQUEST, e.getMessage());
-        return ResponseEntity.status(HttpServletResponse.SC_BAD_REQUEST).body(error);
+        return ResponseEntity.status(HttpStatus.BAD_REQUEST)
+                .body(ApiUtil.error(HttpStatus.BAD_REQUEST.value(), e.getMessage()));
     }
 
+    @ExceptionHandler(Exception.class)
+    protected ResponseEntity<?> handleAllUncaughtException(Exception e) {
+        log.error("Uncaught exception occurred: ", e);
+        return ResponseEntity.status(HttpStatus.INTERNAL_SERVER_ERROR)
+                .body(ApiUtil.error(HttpStatus.INTERNAL_SERVER_ERROR.value(),
+                        "서버 오류가 발생했습니다. 관리자에게 문의해주세요."));
+    }
 }

--- a/src/main/java/com/popflix/global/config/RedisConfig.java
+++ b/src/main/java/com/popflix/global/config/RedisConfig.java
@@ -8,6 +8,12 @@ import org.springframework.data.redis.connection.RedisStandaloneConfiguration;
 import org.springframework.data.redis.connection.lettuce.LettuceConnectionFactory;
 import org.springframework.data.redis.core.RedisTemplate;
 import org.springframework.data.redis.serializer.StringRedisSerializer;
+import org.springframework.data.redis.connection.lettuce.LettuceClientConfiguration;
+import io.lettuce.core.ClientOptions;
+import io.lettuce.core.protocol.ProtocolVersion;
+import org.springframework.data.redis.serializer.GenericJackson2JsonRedisSerializer;
+
+import java.time.Duration;
 
 @Configuration
 public class RedisConfig {
@@ -18,20 +24,46 @@ public class RedisConfig {
     @Value("${spring.data.redis.port}")
     private int redisPort;
 
+    @Value("${spring.data.redis.ssl.enabled}")
+    private boolean enableSsl;
+
+    @Value("${spring.data.redis.timeout}")
+    private long timeout;
+
     @Bean
     public RedisConnectionFactory redisConnectionFactory() {
-        RedisStandaloneConfiguration config = new RedisStandaloneConfiguration(redisHost, redisPort);
-        return new LettuceConnectionFactory(config);
+        RedisStandaloneConfiguration redisConfig = new RedisStandaloneConfiguration(redisHost, redisPort);
+
+        LettuceClientConfiguration.LettuceClientConfigurationBuilder builder =
+                LettuceClientConfiguration.builder()
+                        .commandTimeout(Duration.ofMillis(timeout))
+                        .clientOptions(ClientOptions.builder()
+                                .protocolVersion(ProtocolVersion.RESP3)
+                                .build());
+
+        if (enableSsl) {
+            builder.useSsl().disablePeerVerification();
+        }
+
+        return new LettuceConnectionFactory(redisConfig, builder.build());
     }
 
     @Bean
-    public RedisTemplate<String, String> redisTemplate() {
-        RedisTemplate<String, String> redisTemplate = new RedisTemplate<>();
-        redisTemplate.setConnectionFactory(redisConnectionFactory());
+    public RedisTemplate<String, Object> redisTemplate(RedisConnectionFactory connectionFactory) {
+        RedisTemplate<String, Object> redisTemplate = new RedisTemplate<>();
+        redisTemplate.setConnectionFactory(connectionFactory);
+
         redisTemplate.setKeySerializer(new StringRedisSerializer());
-        redisTemplate.setValueSerializer(new StringRedisSerializer());
         redisTemplate.setHashKeySerializer(new StringRedisSerializer());
-        redisTemplate.setHashValueSerializer(new StringRedisSerializer());
+
+        GenericJackson2JsonRedisSerializer jsonSerializer = new GenericJackson2JsonRedisSerializer();
+        redisTemplate.setValueSerializer(jsonSerializer);
+        redisTemplate.setHashValueSerializer(jsonSerializer);
+
+        redisTemplate.setEnableTransactionSupport(true);
+        redisTemplate.setEnableDefaultSerializer(false);
+        redisTemplate.afterPropertiesSet();
+
         return redisTemplate;
     }
 }

--- a/src/main/java/com/popflix/global/config/SwaggerConfig.java
+++ b/src/main/java/com/popflix/global/config/SwaggerConfig.java
@@ -13,23 +13,29 @@ public class SwaggerConfig {
 
     @Bean
     public OpenAPI openAPI() {
-        Info info = new Info()
-                .title("POPFLIX API Documentation")
-                .version("v1.0")
-                .description("POPFLIX 백엔드 API 문서");
+        SecurityScheme cookieAuth = new SecurityScheme()
+                .type(SecurityScheme.Type.APIKEY)
+                .in(SecurityScheme.In.COOKIE)
+                .name("access_token");
 
-        SecurityScheme securityScheme = new SecurityScheme()
+        SecurityScheme bearerAuth = new SecurityScheme()
                 .type(SecurityScheme.Type.HTTP)
                 .scheme("bearer")
-                .bearerFormat("JWT")
-                .in(SecurityScheme.In.HEADER)
-                .name("Authorization");
-
-        SecurityRequirement securityRequirement = new SecurityRequirement().addList("bearerAuth");
+                .bearerFormat("JWT");
 
         return new OpenAPI()
-                .info(info)
-                .addSecurityItem(securityRequirement)
-                .components(new Components().addSecuritySchemes("bearerAuth", securityScheme));
+                .components(new Components()
+                        .addSecuritySchemes("cookieAuth", cookieAuth)
+                        .addSecuritySchemes("bearerAuth", bearerAuth))
+                .info(new Info()
+                        .title("PopFlix API")
+                        .version("1.0.0")
+                        .description("PopFlix API Documentation<br><br>" +
+                                "인증 방식:<br>" +
+                                "1. Cookie Authentication (Production)<br>" +
+                                "2. Bearer Token Authentication (Development/Test)<br><br>" +
+                                "개발 테스트 시에는 Bearer Token 방식을 사용하시면 됩니다."))
+                .addSecurityItem(new SecurityRequirement().addList("cookieAuth"))
+                .addSecurityItem(new SecurityRequirement().addList("bearerAuth"));
     }
 }


### PR DESCRIPTION
- Token 관리 개선
  - accessToken을 HttpOnly + Secure 쿠키로 관리
  - refreshToken을 Redis에 암호화하여 저장
  - Redis 블랙리스트로 토큰 무효화 지원
  
- 인증 방식 이중화
  - Production: 쿠키 기반 인증 (더 안전)
  - Development: Bearer 토큰 지원 (테스트 용이)

- 보안 강화
  - JWT 서명키 SHA-512 해싱 적용
  - CSRF 보호 활성화 
  - Content Security Policy 적용
  - CORS 설정 구체화

- 개발 편의성
  - Swagger에서 두 가지 인증방식 모두 테스트 가능
  - 개발환경에서 Bearer 토큰으로 쉽게 테스트